### PR TITLE
Remove dom parser

### DIFF
--- a/src/actors/storage/s3.ts
+++ b/src/actors/storage/s3.ts
@@ -258,15 +258,17 @@ export class S3ActorStorage implements ActorStorage {
       await response.body?.cancel();
       throw new Error(`Failed to list objects: ${response.statusText}`);
     }
-    const text = await response.text();
-    const parser = new DOMParser();
-    const xmlDoc = parser.parseFromString(text, "application/xml");
-    const keys = Array.from(xmlDoc.getElementsByTagName("Contents"))
-      .map((content) => {
-        const keyNode = content.getElementsByTagName("Key")[0];
-        return { Key: keyNode.textContent! };
-      });
-    return keys;
+    const _text = await response.text();
+
+    throw new Error("not implemented for now");
+    // const parser = new DOMParser();
+    // const xmlDoc = parser.parseFromString(text, "application/xml");
+    // const keys = Array.from(xmlDoc.getElementsByTagName("Contents"))
+    //   .map((content) => {
+    //     const keyNode = content.getElementsByTagName("Key")[0];
+    //     return { Key: keyNode.textContent! };
+    //   });
+    // return keys;
   }
 
   // Helper method to generate signed headers for S3 requests


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Revert**
  * Temporarily disabled S3 object listing. Attempts to list objects now return an error, impacting features that browse, sync, or enumerate bucket contents.
  * No other storage operations are affected.
  * Workaround: Access objects directly by known keys or use alternative tools to obtain listings until support is restored.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->