### PR TITLE
Fixes should parse response bug

### DIFF
--- a/src/actors/stub/stubutil.ts
+++ b/src/actors/stub/stubutil.ts
@@ -566,6 +566,10 @@ export const createHttpInvoker = <
         );
         throw deserializedError;
       }
+      if (resp.headers.get(SHOULD_PARSE_RESPONSE_HEADER) === "false") {
+        return resp;
+      }
+
       if (
         resp.headers.get("content-type") ===
           EVENT_STREAM_RESPONSE_HEADER
@@ -581,9 +585,7 @@ export const createHttpInvoker = <
       if (resp.status === 204) {
         return;
       }
-      if (resp.headers.get(SHOULD_PARSE_RESPONSE_HEADER) === "false") {
-        return resp;
-      }
+
       if (
         resp.headers.get("content-type")?.includes("application/octet-stream")
       ) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * When a response header/setting indicates parsing is disabled, HTTP requests now return the raw response immediately.
  * Improves compatibility for endpoints where clients handle their own parsing (e.g., streaming, custom formats).
  * Reduces unnecessary processing by bypassing JSON/text/binary parsing when not needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->