### PR TITLE
Revert "Fixes should parse response bug"

### DIFF
--- a/src/actors/stub/stubutil.ts
+++ b/src/actors/stub/stubutil.ts
@@ -566,10 +566,6 @@ export const createHttpInvoker = <
         );
         throw deserializedError;
       }
-      if (resp.headers.get(SHOULD_PARSE_RESPONSE_HEADER) === "false") {
-        return resp;
-      }
-
       if (
         resp.headers.get("content-type") ===
           EVENT_STREAM_RESPONSE_HEADER
@@ -585,7 +581,9 @@ export const createHttpInvoker = <
       if (resp.status === 204) {
         return;
       }
-
+      if (resp.headers.get(SHOULD_PARSE_RESPONSE_HEADER) === "false") {
+        return resp;
+      }
       if (
         resp.headers.get("content-type")?.includes("application/octet-stream")
       ) {


### PR DESCRIPTION
Reverts deco-cx/actors#42

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected response handling order so 204 No Content responses are properly recognized before any opt-out of response parsing is applied. This prevents premature early returns, reducing false negatives on successful no-content responses and improving consistency and reliability when parsing is disabled or selectively bypassed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->